### PR TITLE
Upgrade AGP and Kotlin versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Movie App ![Kotlin](https://img.shields.io/badge/kotlin-1.8.20-orange) ![Android Gradle Plugin](https://img.shields.io/badge/agp-7.4.2-blue) 
+# Movie App ![Kotlin](https://img.shields.io/badge/kotlin-1.9.0-orange) ![Android Gradle Plugin](https://img.shields.io/badge/agp-8.1.0-blue) 
 
 <img src="images/app_tour.gif" width="250" align="right" hspace="0">
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -24,3 +24,27 @@
 
 # @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
 -keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+# Prevent R8 in full mode stripping the generic signature
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# Keep the Result class, but allows its unused members to be obfuscated or removed.
+# Required for ResultCallAdapterFactory
+-keep,allowobfuscation,allowshrinking class kotlin.Result
+
+# Suppress warnings about missing classes from the classpath.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/app/src/main/kotlin/com/azizutku/movie/BaseApplication.kt
+++ b/app/src/main/kotlin/com/azizutku/movie/BaseApplication.kt
@@ -1,6 +1,7 @@
 package com.azizutku.movie
 
 import android.app.Application
+import android.content.pm.ApplicationInfo
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 import timber.log.Timber.DebugTree
@@ -21,7 +22,8 @@ class BaseApplication : Application() {
     }
 
     private fun initTimber() {
-        if (BuildConfig.DEBUG) {
+        val isDebuggable = applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+        if (isDebuggable) {
             Timber.plant(
                 object : DebugTree() {
                     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
@@ -32,10 +34,10 @@ class BaseApplication : Application() {
                         return String.format(
                             FORMAT_TIMBER_CREATE_STACK_ELEMENT,
                             element.methodName,
-                            super.createStackElementTag(element)
+                            super.createStackElementTag(element),
                         )
                     }
-                }
+                },
             )
         }
     }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 group = "com.azizutku.movie.buildlogic"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -37,7 +37,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                     BuildTypeRelease.create(this, signingConfigs)
                     BuildTypeBenchmark.create(this, signingConfigs)
                 }
-                packagingOptions {
+                packaging {
                     resources.excludes.add("META-INF/AL2.0")
                     resources.excludes.add("META-INF/LGPL2.1")
                 }

--- a/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/BuildProductFlavor.kt
+++ b/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/BuildProductFlavor.kt
@@ -20,7 +20,7 @@ enum class BuildProductFlavor(
 }
 
 fun configureFlavors(
-    commonExtension: CommonExtension<*, *, *, *>,
+    commonExtension: CommonExtension<*, *, *, *, *>,
 ) {
     commonExtension.apply {
         flavorDimensions += FlavorDimension.values().map { dimension ->

--- a/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/Detekt.kt
+++ b/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/Detekt.kt
@@ -27,9 +27,9 @@ internal fun Project.configureDetekt() {
         }
     }
     tasks.withType<Detekt>().configureEach {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
     tasks.withType<DetektCreateBaselineTask>().configureEach {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/GitHooks.kt
+++ b/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/GitHooks.kt
@@ -49,6 +49,6 @@ internal fun Project.configureGitHooks() {
 }
 
 internal fun isLinuxOrMacOs(): Boolean {
-    val osName = System.getProperty("os.name").toLowerCase(Locale.ROOT)
+    val osName = System.getProperty("os.name").lowercase(Locale.ROOT)
     return listOf("linux", "mac os", "macos").contains(osName)
 }

--- a/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/KotlinAndroid.kt
@@ -8,7 +8,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
 internal fun configureKotlinAndroid(
-    commonExtension: CommonExtension<*, *, *, *>,
+    commonExtension: CommonExtension<*, *, *, *, *>,
     optInCoroutines: Boolean = true,
 ) {
     commonExtension.apply {
@@ -19,11 +19,11 @@ internal fun configureKotlinAndroid(
             testInstrumentationRunner = AndroidConfig.TEST_INSTRUMENTATION_RUNNER
         }
         compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
         kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_11.toString()
+            jvmTarget = JavaVersion.VERSION_17.toString()
 
             // Treat all Kotlin warnings as errors (disabled by default)
             allWarningsAsErrors = true
@@ -43,6 +43,6 @@ internal fun configureKotlinAndroid(
     }
 }
 
-internal fun CommonExtension<*, *, *, *>.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
+internal fun CommonExtension<*, *, *, *, *>.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
     (this as ExtensionAware).extensions.configure("kotlinOptions", block)
 }

--- a/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/ProjectExtensions.kt
@@ -6,7 +6,7 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
-const val JDK_VERSION = 11
+const val JDK_VERSION = 17
 
 fun Project.getLocalProperty(propertyName: String): String {
     return getLocalProperty(propertyName, this)

--- a/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/StringExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/azizutku/movie/extensions/StringExtensions.kt
@@ -1,0 +1,6 @@
+package com.azizutku.movie.extensions
+
+import java.util.Locale
+
+internal fun String.capitalize(locale: Locale): String =
+    this.replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }

--- a/build-logic/convention/src/main/kotlin/com/azizutku/movie/utils/GradleManagedDevices.kt
+++ b/build-logic/convention/src/main/kotlin/com/azizutku/movie/utils/GradleManagedDevices.kt
@@ -1,8 +1,8 @@
 package com.azizutku.movie.utils
 
-import androidx.navigation.safe.args.generator.ext.capitalize
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.ManagedVirtualDevice
+import com.azizutku.movie.extensions.capitalize
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.invoke
 import java.util.Locale
@@ -11,7 +11,7 @@ private const val API_LEVEL_30 = 30
 private const val API_LEVEL_31 = 31
 
 internal fun configureGradleManagedDevices(
-    commonExtension: CommonExtension<*, *, *, *>,
+    commonExtension: CommonExtension<*, *, *, *, *>,
 ) {
     val deviceConfigs = listOf(
         DeviceConfig("Pixel 4", API_LEVEL_30, "aosp-atd"),
@@ -56,7 +56,7 @@ private data class DeviceConfig(
     val groups: List<String>? = null,
 ) {
     val taskName = buildString {
-        append(device.toLowerCase(Locale.ROOT).replace(" ", ""))
+        append(device.lowercase(Locale.ROOT).replace(" ", ""))
         append("Api")
         append(apiLevel.toString())
         append(systemImageSource.capitalize(Locale.ROOT).replace("-", ""))

--- a/build-logic/convention/src/main/kotlin/com/azizutku/movie/utils/VersionUtils.kt
+++ b/build-logic/convention/src/main/kotlin/com/azizutku/movie/utils/VersionUtils.kt
@@ -7,7 +7,7 @@ object VersionUtils {
     private val stableKeywords = listOf("RELEASE", "FINAL", "GA")
 
     fun isNonStable(version: String): Boolean {
-        val hasStableKeyword = stableKeywords.any { version.toUpperCase(Locale.ROOT).contains(it) }
+        val hasStableKeyword = stableKeywords.any { version.uppercase(Locale.ROOT).contains(it) }
         val regex = "^[0-9,.v-]+(-r)?$".toRegex()
         val isStable = hasStableKeyword || regex.matches(version)
         return isStable.not()

--- a/build-logic/gradle/wrapper/gradle-wrapper.properties
+++ b/build-logic/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -23,6 +23,8 @@ android {
             throw InvalidUserDataException(com.azizutku.movie.BuildConstants.MESSAGE_API_KEY_EXCEPTION)
         }
     }
+
+    buildFeatures.buildConfig = true
 }
 
 dependencies {

--- a/core/network/gradle.properties
+++ b/core/network/gradle.properties
@@ -1,0 +1,1 @@
+android.enableBuildConfigAsBytecode=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ turbine = "0.12.3"
 archCore = "2.2.0"
 
 # Dependency versions of the included build-logic
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.1.0"
 kotlin = "1.8.20"
 detekt = "1.22.0"
 javapoet = "1.13.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ appCompat = "1.6.1"
 constraintlayout = "2.1.4"
 material = "1.8.0"
 splashScreen = "1.0.0"
-hilt = "2.45"
+hilt = "2.47"
 coroutines = "1.6.4"
 timber = "5.0.1"
 fragmentKtx = "1.5.6"
@@ -36,16 +36,16 @@ archCore = "2.2.0"
 
 # Dependency versions of the included build-logic
 androidGradlePlugin = "8.1.0"
-kotlin = "1.8.20"
+kotlin = "1.9.0"
 detekt = "1.22.0"
 javapoet = "1.13.0"
 navigationSafeargs = "2.5.3"
-kspGradlePlugin = "1.8.20-1.0.10"
+kspGradlePlugin = "1.9.0-1.0.13"
 
 # Plugins
 ktlintPlugin = "11.3.1"
 versionsPlugin = "0.46.0"
-hiltPlugin = "2.45"
+hiltPlugin = "2.47"
 kotlinSerializationPlugin = "1.7.10"
 jacocoPlugin = "0.8.9"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Sep 18 13:12:04 TRT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bump AGP version to 8.1.0 from 7.4.2
Bump Kotlin version to 1.9.0 from 1.8.20

## Additional Changes

- Bump KSP plugin to 1.9.0-1.0.13
- Bump Hilt to 2.47